### PR TITLE
Fixed a small typo(?)

### DIFF
--- a/snake.py
+++ b/snake.py
@@ -84,7 +84,7 @@ while True:
 					swapper = RIGHT
 				elif event.key == K_DOWN or event.key == ord('s'):
 					swapper = DOWN
-				elif event.key == K_UP or event.key == ord('W'):
+				elif event.key == K_UP or event.key == ord('w'):
 					swapper = UP
 			orig = swapper
 		


### PR DESCRIPTION
The key 'w' was not working as it was supposed to viz similar to 'UP' arrow. I found this was due to the use of 'W' instead 'w' on line 87.